### PR TITLE
Mandarijština

### DIFF
--- a/common-dicts/zh.cljc
+++ b/common-dicts/zh.cljc
@@ -1,0 +1,20 @@
+(ns orgpad.common.i18n.dict.de)
+
+(def dict
+  "A dictionary map from keywords to the corresponding English texts."
+  {:lang/name                           "中文（简体字）"
+   :lang/en-name                        "Chinese（Simplified）"
+   :lang/plural-breaks                  [0 1 2]             ; Counts of elements for which the next translation for :i18n/plural is used.
+
+   :date/january       "一月"
+   :date/february      "二月"
+   :date/march         "三月"
+   :date/april         "四月"
+   :date/may           "五月“
+   :date/june          "六月"
+   :date/july          "七月"
+   :date/august        "八月"
+   :date/september     "九月"
+   :date/october       "十月"
+   :date/november      "十一月"
+   :date/december      "十二月"})


### PR DESCRIPTION
Mandarijština - pevninská, zjednodušená čínština